### PR TITLE
Add sample translations and local question loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# the-future-app
+# The Future App
+
+This simple web application displays driving practice questions in French and English.
+
+### Usage
+
+Open `index.html` in a browser. Use the **FR / EN** button to toggle languages.
+Click **Show Answer** to reveal the answer and **Next** to move to the next question.
+
+Questions are loaded from `questions.json`, which contains both the original
+French text and the English translation. Add more entries to this file as needed.

--- a/index.html
+++ b/index.html
@@ -15,7 +15,8 @@
         <section id="quiz-section">
             <h2>Practice Quiz</h2>
             <div id="question-container"></div>
-            <div id="options-container"></div>
+            <div id="answer-container"></div>
+            <button id="show-answer">Show Answer</button>
             <button id="next-question">Next</button>
             <p id="progress-tracker"></p>
         </section>

--- a/questions.json
+++ b/questions.json
@@ -1,0 +1,62 @@
+[
+  {
+    "fr": "Montrez la commande de réglage de hauteur des feux.",
+    "en": "Show the headlight height adjustment control.",
+    "answer_fr": "Dispositif situé en général à gauche du volant.",
+    "answer_en": "Control usually located to the left of the steering wheel."
+  },
+  {
+    "fr": "Pourquoi doit-on régler la hauteur des feux ?",
+    "en": "Why should the headlight height be adjusted?",
+    "answer_fr": "Pour ne pas éblouir les autres usagers.",
+    "answer_en": "To avoid dazzling other road users."
+  },
+  {
+    "fr": "Comment et pourquoi protéger une zone de danger en cas d’accident de la route ?",
+    "en": "How and why should a danger zone be secured in the event of a road accident?",
+    "answer_fr": "En délimitant clairement et largement la zone de danger de façon visible pour protéger les victimes et éviter un sur-accident.",
+    "answer_en": "By clearly marking out the danger area so it is visible, to protect victims and avoid another accident."
+  },
+  {
+    "fr": "Montrez où s'effectue le remplissage du produit lave-glace.",
+    "en": "Show where to refill the windshield washer fluid.",
+    "answer_fr": "Ouvrir le capot et montrer le bocal de liquide lave-glace.",
+    "answer_en": "Open the hood and point to the washer fluid reservoir."
+  },
+  {
+    "fr": "Pourquoi est-il préférable d'utiliser un liquide spécial en hiver ?",
+    "en": "Why is it better to use a special fluid in winter?",
+    "answer_fr": "Pour éviter le gel du liquide.",
+    "answer_en": "To prevent the fluid from freezing."
+  },
+  {
+    "fr": "Quels comportements adopter en cas de diffusion du signal d’alerte du SAIP ?",
+    "en": "What should you do when the SAIP alert signal is broadcast?",
+    "answer_fr": "Se mettre en sécurité, s'informer grâce aux médias et respecter les consignes des autorités.",
+    "answer_en": "Get to safety, follow news from authorities and obey their instructions."
+  },
+  {
+    "fr": "Mettez le rétroviseur intérieur en position \"nuit\".",
+    "en": "Set the interior rear-view mirror to the night position.",
+    "answer_fr": "Actionner la commande du rétroviseur ou expliquer le dispositif automatique.",
+    "answer_en": "Operate the mirror switch or mention the automatic system if equipped."
+  },
+  {
+    "fr": "Quel est l’intérêt de la position nuit ?",
+    "en": "What is the advantage of the night position?",
+    "answer_fr": "Ne pas être ébloui par les feux du véhicule suiveur.",
+    "answer_en": "To avoid being dazzled by the following vehicle's lights."
+  },
+  {
+    "fr": "Comment est composé le signal d’alerte du SAIP diffusé par les sirènes ?",
+    "en": "How is the SAIP alert signal broadcast by sirens composed?",
+    "answer_fr": "Il se compose du Signal National d'Alerte en trois cycles successifs et du signal de fin d'alerte continu.",
+    "answer_en": "It consists of the National Alert Signal in three successive cycles and a continuous end-of-alert signal."
+  },
+  {
+    "fr": "Contrôlez l'état du flanc sur l'un des pneumatiques.",
+    "en": "Check the condition of one tyre's sidewall.",
+    "answer_fr": "Vérifier qu'il est en bon état et signaler toute anomalie.",
+    "answer_en": "Ensure it is in good condition and report any defects."
+  }
+]

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,104 +1,54 @@
-// Firebase Configuration (Replace with your own if needed)
-const firebaseConfig = {
-    apiKey: "YOUR_API_KEY",
-    authDomain: "YOUR_APP.firebaseapp.com",
-    projectId: "YOUR_PROJECT_ID",
-    storageBucket: "YOUR_APP.appspot.com",
-    messagingSenderId: "YOUR_SENDER_ID",
-    appId: "YOUR_APP_ID"
-};
-
-// Initialize Firebase
-firebase.initializeApp(firebaseConfig);
-const db = firebase.firestore();
-
 let questions = [];
 let currentQuestion = 0;
 let language = 'fr';
-let score = 0;
-let timer;
 
 const questionContainer = document.getElementById('question-container');
-const optionsContainer = document.getElementById('options-container');
+const answerContainer = document.getElementById('answer-container');
 const progressTracker = document.getElementById('progress-tracker');
 const languageToggle = document.getElementById('language-toggle');
-const timerDisplay = document.getElementById('timer');
+const nextButton = document.getElementById('next-question');
+const showAnswerButton = document.getElementById('show-answer');
 
 async function loadQuestions() {
     try {
-        const querySnapshot = await db.collection("questions").get();
-        querySnapshot.forEach((doc) => {
-            questions.push(doc.data());
-        });
-
-        // Shuffle the questions for randomization
-        questions.sort(() => Math.random() - 0.5);
-
-        // Start the timer and show the first question
-        startTimer(40 * 60);
+        const response = await fetch('questions.json');
+        questions = await response.json();
         showQuestion();
-    } catch (error) {
-        alert("Error loading questions: " + error.message);
+    } catch (err) {
+        alert('Error loading questions: ' + err.message);
     }
-}
-
-function startTimer(duration) {
-    let time = duration;
-    timer = setInterval(() => {
-        let minutes = Math.floor(time / 60);
-        let seconds = time % 60;
-        timerDisplay.textContent = `Time Left: ${minutes}:${seconds < 10 ? '0' : ''}${seconds}`;
-        if (--time < 0) {
-            clearInterval(timer);
-            alert('Time is up!');
-            showResults();
-        }
-    }, 1000);
 }
 
 function showQuestion() {
     if (currentQuestion >= questions.length) {
-        clearInterval(timer);
-        showResults();
+        questionContainer.innerText = 'No more questions.';
+        answerContainer.innerText = '';
+        progressTracker.innerText = `Questions: ${questions.length}`;
+        nextButton.disabled = true;
+        showAnswerButton.disabled = true;
         return;
     }
-
-    const question = questions[currentQuestion];
-    questionContainer.innerText = language === 'fr' ? question.fr : question.en;
-    optionsContainer.innerHTML = '';
-
-    question.options.forEach((option, index) => {
-        const button = document.createElement('button');
-        button.innerText = option;
-        button.onclick = () => checkAnswer(index);
-        optionsContainer.appendChild(button);
-    });
-
+    const q = questions[currentQuestion];
+    questionContainer.innerText = language === 'fr' ? q.fr : q.en;
+    answerContainer.innerText = '';
     progressTracker.innerText = `Question ${currentQuestion + 1} of ${questions.length}`;
 }
 
-function checkAnswer(selected) {
-    const correct = questions[currentQuestion].answer;
-    if (selected === correct) {
-        score++;
-        alert('Correct!');
-    } else {
-        alert(`Wrong! The correct answer was: ${questions[currentQuestion].options[correct]}`);
+showAnswerButton.addEventListener('click', () => {
+    if (currentQuestion < questions.length) {
+        const q = questions[currentQuestion];
+        answerContainer.innerText = language === 'fr' ? q.answer_fr : q.answer_en;
     }
+});
+
+nextButton.addEventListener('click', () => {
     currentQuestion++;
     showQuestion();
-}
-
-function showResults() {
-    alert(`You scored ${score} out of ${questions.length}`);
-    progressTracker.innerText = `Final Score: ${score}/${questions.length}`;
-}
+});
 
 languageToggle.addEventListener('click', () => {
     language = language === 'fr' ? 'en' : 'fr';
     showQuestion();
 });
-
-document.getElementById('next-question').addEventListener('click', loadQuestions);
 
 loadQuestions();


### PR DESCRIPTION
## Summary
- switch app to load questions from a local `questions.json` file
- simplify quiz UI and logic for show-answer/next
- add 10 example question translations in `questions.json`
- update README with usage notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ac42aa9f08321a7c12770e76387bd