### PR TITLE
Add .gitattributes for PNG files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.png binary


### PR DESCRIPTION
## Summary
- ensure PNG images are treated as binary files by git

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ad331c3c083219e40119d401bbbfb