### PR TITLE
Improve image alt text

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -62,7 +62,7 @@ function showQuestion() {
     questionContainer.innerHTML = '';
     const img = document.createElement('img');
     img.src = q.image || 'images/placeholder.png';
-    img.alt = 'illustration';
+    img.alt = language === 'fr' ? q.fr : q.en;
     img.className = 'question-image';
     questionContainer.appendChild(img);
 


### PR DESCRIPTION
## Summary
- include question text in image `alt` attribute for better accessibility

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ad29b2ba883218f2023f343c89a11