### PR TITLE
Fix: restore main.js to previous version

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,74 @@
-@@ -72,43 +72,48 @@ function showQuestion() {
+let questions = [];
+let currentQuestion = 0;
+let language = 'fr';
+let score = 0;
+let timer;
+
+const questionContainer = document.getElementById('question-container');
+const optionsContainer = document.getElementById('options-container');
+const answerContainer = document.getElementById('answer-container');
+const progressTracker = document.getElementById('progress-tracker');
+const languageToggle = document.getElementById('language-toggle');
+const timerDisplay = document.getElementById('timer');
+const nextButton = document.getElementById('next-question');
+const showAnswerButton = document.getElementById('show-answer');
+
+async function loadQuestions() {
+    try {
+        const response = await fetch('questions.json');
+        questions = await response.json();
+
+        // Shuffle the questions randomly
+        questions.sort(() => Math.random() - 0.5);
+
+        // Start timer (40 minutes)
+        startTimer(40 * 60);
+
+        showQuestion();
+    } catch (error) {
+        alert("Error loading questions: " + error.message);
+    }
+}
+
+function startTimer(duration) {
+    let time = duration;
+    timer = setInterval(() => {
+        let minutes = Math.floor(time / 60);
+        let seconds = time % 60;
+        timerDisplay.textContent = `Time Left: ${minutes}:${seconds < 10 ? '0' : ''}${seconds}`;
+        if (--time < 0) {
+            clearInterval(timer);
+            alert('Time is up!');
+            showResults();
+        }
+    }, 1000);
+}
+
+function showQuestion() {
+    if (currentQuestion >= questions.length) {
+        clearInterval(timer);
+        showResults();
+        questionContainer.innerText = 'No more questions.';
+        answerContainer.innerText = '';
+        progressTracker.innerText = `Questions: ${questions.length}`;
+        nextButton.disabled = true;
+        showAnswerButton.disabled = true;
+        return;
+    }
+
+    const q = questions[currentQuestion];
+
+    // Clear previous question and display image
+    questionContainer.innerHTML = '';
+    const img = document.createElement('img');
+    img.src = q.image || 'images/placeholder.png';
+    img.alt = language === 'fr' ? q.fr : q.en;
+    img.className = 'question-image';
+    questionContainer.appendChild(img);
+
+    // Display question text
+    const p = document.createElement('p');
+    p.innerText = language === 'fr' ? q.fr : q.en;
     questionContainer.appendChild(p);
 
     // Display options


### PR DESCRIPTION
## Summary
- revert `scripts/main.js` to state before commit `21aec56830cdc5c5067fe5534bc4f4ca4976016f`
- ensure code contains variable declarations, `loadQuestions`, `startTimer`, `showQuestion`, and results logic without leftover patch markers

## Testing
- `grep -n "@@" -n scripts/main.js`


------
https://chatgpt.com/codex/tasks/task_e_686c239968148321a0ba656f9d611324