### PR TITLE
Update README with local server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,19 @@ This simple web application displays driving practice questions in French and En
 
 ### Usage
 
-Open `index.html` in a browser. Use the **FR / EN** button to toggle languages.
+Start a simple HTTP server from the project directory, for example:
+
+```bash
+python -m http.server
+```
+
+Then open `http://localhost:8000/index.html` in your browser. Use the **FR / EN** button to toggle languages.
 Click **Show Answer** to reveal the answer and **Next** to move to the next question.
 
 Questions are loaded from `questions.json`, which now also includes an `image`
 field for each entry. Images are stored in the `images` folder. A placeholder is
 provided for all questions by default. The repository contains a small sample of
 questions; you can expand the list by editing the JSON file and adding your own
-images.
+images. If you try opening `index.html` directly from the filesystem, the
+browser may block the fetch request for `questions.json`, causing the quiz to
+fail to load. Running a local HTTP server avoids this issue.


### PR DESCRIPTION
## Summary
- update usage documentation to recommend starting a local HTTP server
- mention that fetching `questions.json` can fail when opening the HTML file directly

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686c23a5ebc883218b5683d26c8ed25e