### PR TITLE
Restore Next button functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Each question entry in `questions.json` defines text in both languages, a list o
 ### Usage
 
 Open `index.html` in a browser. Use the **FR / EN** button to toggle languages.
-Click **Show Answer** to reveal the answer and **Next** to move to the next question.
+Select an option to check your answer. Click **Show Answer** for an explanation and press **Next** to move forward. Your total score appears after all questions are answered or the timer ends.
 Questions are loaded from `questions.json`, which includes an `image` field for
 each entry. All images should be placed in the `images` folder. A generic
 `placeholder.png` is bundled and will be used whenever an entry does not specify

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -96,19 +96,13 @@ function checkAnswer(selected) {
         alert(`Wrong! The correct answer was: ${opts[correct]}`);
     }
 
-    currentQuestion++;
-
-    if (currentQuestion >= questions.length) {
-        showResults();
-    } else {
-        showQuestion();
-    }
 }
 
 function showResults() {
     alert(`You scored ${score} out of ${questions.length}`);
     progressTracker.innerText = `Final Score: ${score}/${questions.length}`;
 }
+
 
 showAnswerButton.addEventListener('click', () => {
     if (currentQuestion < questions.length) {
@@ -117,9 +111,14 @@ showAnswerButton.addEventListener('click', () => {
     }
 });
 
-// Hide and disable the Next button since progression is automatic
-nextButton.disabled = true;
-nextButton.style.display = 'none';
+nextButton.addEventListener('click', () => {
+    currentQuestion++;
+    if (currentQuestion >= questions.length) {
+        showResults();
+    } else {
+        showQuestion();
+    }
+});
 
 languageToggle.addEventListener('click', () => {
     language = language === 'fr' ? 'en' : 'fr';


### PR DESCRIPTION
## Summary
- restore manual navigation with the Next button
- document quiz flow and scoring in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c2f2f4d688321988bb44fcbdf4156