### PR TITLE
Add missing quiz controls

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -117,9 +117,10 @@ showAnswerButton.addEventListener('click', () => {
     }
 });
 
-// Hide and disable the Next button since progression is automatic
-nextButton.disabled = true;
-nextButton.style.display = 'none';
+nextButton.addEventListener('click', () => {
+    currentQuestion++;
+    showQuestion();
+});
 
 languageToggle.addEventListener('click', () => {
     language = language === 'fr' ? 'en' : 'fr';


### PR DESCRIPTION
## Summary
- restore manual navigation through Next button
- keep showResults() available for end-of-quiz message
- ensure answer and language toggle actions work

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c2f2714f48321b36ad8e612cc4afa