### PR TITLE
Build The Deal Desk multi-profile job-search app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,37 @@
+# Language model provider: openai or anthropic
+LLM_PROVIDER=
+# Server-side OpenAI API key
+OPENAI_API_KEY=
+# Server-side Anthropic API key
+ANTHROPIC_API_KEY=
+# Model name for the selected provider
+LLM_MODEL=
+
+# Adzuna developer credentials
+ADZUNA_APP_ID=
+ADZUNA_APP_KEY=
+
+# France Travail OAuth client credentials
+FRANCE_TRAVAIL_CLIENT_ID=
+FRANCE_TRAVAIL_CLIENT_SECRET=
+
+# Shared secret required in x-run-secret for POST /api/run/daily
+RUN_SECRET=
+
+# Resend API key. Leave empty if using SMTP.
+RESEND_API_KEY=
+# Recipient for the daily digest
+DIGEST_TO_EMAIL=
+# SMTP alternative for digest delivery
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASS=
+SMTP_FROM=
+
+# Prisma database URL. SQLite is recommended locally.
+DATABASE_URL="file:./dev.db"
+# Application timezone
+TIMEZONE=Europe/Paris
+# Public application URL used for digest links
+APP_BASE_URL=http://localhost:3000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md
+
+## Project
+
+The Deal Desk is a multi-profile AI-assisted job-search desk for procurement professionals. It supports separate candidate profiles, role sourcing, fit assessment, tailored CV bullets, cover email generation, pipeline tracking and daily digest automation.
+
+## Run commands
+
+```bash
+cp .env.example .env
+npm install
+npx prisma migrate dev --name init
+npm run dev
+```
+
+Open `http://localhost:3000`.
+
+## Test commands
+
+```bash
+npm test
+npm run build
+```
+
+## Useful API routes
+
+- `GET /api/health` checks database, model configuration, Adzuna and France Travail configuration.
+- `GET /api/profiles` lists candidate profiles.
+- `POST /api/profiles` creates or updates a profile.
+- `GET /api/search-configs` lists search configurations.
+- `POST /api/search-configs` creates or updates a search configuration.
+- `GET /api/roles` lists sourced roles.
+- `POST /api/roles/:id/assess` creates a fit assessment for a role/profile pair.
+- `POST /api/assessments/:id/materials` creates tailored CV bullets and a cover email.
+- `POST /api/run/daily` executes the protected daily run. Requires `x-run-secret`.
+- `POST /api/export-delete` exports stored data and deletes it.
+
+## Project structure
+
+- `prisma/schema.prisma` database schema.
+- `src/app` Next.js application and route handlers.
+- `src/lib` backend adapters, prompts, validators, job sources, orchestration and tests.
+
+## Security rules
+
+Keep service credentials in environment variables and route all external provider calls through the backend timeout helper.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,9 @@
+# Decisions
+
+1. The app is multi-profile rather than single-profile. This keeps Ayo's job search and his wife's job search separate while sharing the same sourcing, assessment and pipeline engine.
+2. The data model uses `CandidateProfile` instead of `Profile` and links `SearchConfig` and `Assessment` to a specific profile.
+3. SQLite with Prisma is used locally because this is a single-household tool and keeps personal data under direct control. The schema can move to PostgreSQL later with minimal changes.
+4. The first implementation uses Next.js route handlers as the backend so API keys never enter the browser bundle.
+5. The second profile is created as an editable placeholder. No facts are invented for Ayo's wife.
+6. ROME codes are configurable per search. The initial seed uses the purchasing family examples and should be validated against France Travail referentials before production reliance.
+7. The UI is intentionally functional rather than polished. The priority is secure sourcing, fit scoring, tailoring, pipeline data and daily digest automation.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,46 @@
-# The Future App
-This simple web application displays driving practice questions in French and English.
-Each question entry in `questions.json` defines text in both languages, a list of options, the correct answer index, and an optional `image` path. If no image is specified, the app falls back to `images/placeholder.png`.
+# The Deal Desk
 
-### Usage
+A multi-profile, AI-assisted job-search application for senior procurement professionals.
 
-Open `index.html` in a browser. Use the **FR / EN** button to toggle languages.
-Click **Show Answer** to reveal the answer and **Next** to move to the next question.
-Questions are loaded from `questions.json`, which includes an `image` field for
-each entry. All images should be placed in the `images` folder. A generic
-`placeholder.png` is bundled and will be used whenever an entry does not specify
-its own image. The repository contains only a small sample of questions; feel
-free to extend the list or replace the placeholder with your own artwork by
-editing the JSON file and adding images to the folder.
+The app is designed for Ayo's IT procurement job search and can also be used by a second candidate profile, such as his wife, without mixing CVs, target roles, assessments or pipeline history.
 
-### Adding your own images
+## What it does
 
-Any PNG or JPG file can be placed in the `images` directory. Suitable images can
-come from open-license stock photo sites or pictures you've taken yourself.
-When specifying an image for a question in `questions.json`, set the `image`
-field to the file name relative to this directory, for example:
+- Stores editable candidate profiles.
+- Stores separate search configurations per candidate.
+- Sources roles from Adzuna and France Travail through server-side API calls.
+- De-duplicates roles by company, title and location.
+- Scores fit for each role with a language-model adapter.
+- Generates tailored CV bullets and cover emails.
+- Validates generated text so contractions do not reach the user.
+- Tracks assessment and application history.
+- Sends a daily digest from a protected scheduled endpoint.
+- Exports and deletes all stored personal data.
 
-```json
-"image": "images/my-photo.jpg"
+## Local setup
+
+```bash
+cp .env.example .env
+npm install
+npx prisma migrate dev --name init
+npm run dev
 ```
 
-If the field is omitted, the app automatically displays `images/placeholder.png`.
+Visit `http://localhost:3000`.
+
+## Daily run
+
+```bash
+curl -X POST http://localhost:3000/api/run/daily \
+  -H "x-run-secret: $RUN_SECRET"
+```
+
+## Health check
+
+```bash
+curl http://localhost:3000/api/health
+```
+
+## Notes
+
+This repository previously contained a simple driving-practice static app. The Deal Desk branch replaces it with a Next.js application. Keep all credentials in `.env`; do not place provider credentials in browser code.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  app:
+    image: node:22-alpine
+    working_dir: /app
+    command: sh -c "npm install && npx prisma migrate dev --name init && npm run dev"
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: file:/app/prisma/dev.db

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "2mb"
+    }
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "deal-desk",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "prisma generate && next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest run",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev",
+    "prisma:studio": "prisma studio"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.22.0",
+    "next": "^15.0.3",
+    "nodemailer": "^6.9.16",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "resend": "^4.0.1",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "@types/nodemailer": "^6.4.16",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "eslint": "^9.15.0",
+    "eslint-config-next": "^15.0.3",
+    "prisma": "^5.22.0",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.5"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,101 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model CandidateProfile {
+  id           String   @id @default(cuid())
+  label        String
+  fullText     String
+  name         String
+  email        String?
+  phone        String?
+  targetTitles String   @default("[]")
+  locations    String   @default("[]")
+  isDefault    Boolean  @default(false)
+  updatedAt    DateTime @updatedAt
+  createdAt    DateTime @default(now())
+
+  searchConfigs SearchConfig[]
+  assessments   Assessment[]
+}
+
+model SearchConfig {
+  id            String   @id @default(cuid())
+  profileId     String
+  label         String
+  keywords      String
+  location      String
+  inseeCode     String?
+  radiusKm      Int      @default(50)
+  romeCodes     String   @default("[]")
+  maxDaysOld    Int      @default(7)
+  active        Boolean  @default(true)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  profile CandidateProfile @relation(fields: [profileId], references: [id], onDelete: Cascade)
+}
+
+model Role {
+  id              String   @id @default(cuid())
+  source          String
+  sourceId        String
+  dedupeHash      String   @unique
+  title           String
+  company         String
+  location        String
+  description     String
+  url             String
+  salary          String?
+  postedAt        DateTime?
+  discoveredAt    DateTime @default(now())
+  seen            Boolean  @default(false)
+  firstPassScore  Int      @default(0)
+
+  assessments Assessment[]
+  application Application?
+}
+
+model Assessment {
+  id          String   @id @default(cuid())
+  roleId      String
+  profileId   String
+  fitScore    Int
+  tier        String
+  verdict     String
+  strengths   String
+  gaps        String
+  keywords    String
+  cvBullets   String?
+  coverEmail  String?
+  createdAt   DateTime @default(now())
+
+  role    Role             @relation(fields: [roleId], references: [id], onDelete: Cascade)
+  profile CandidateProfile @relation(fields: [profileId], references: [id], onDelete: Cascade)
+}
+
+model Application {
+  id        String    @id @default(cuid())
+  roleId    String    @unique
+  status    String    @default("identified")
+  appliedAt DateTime?
+  notes     String?
+  updatedAt DateTime  @updatedAt
+  createdAt DateTime  @default(now())
+
+  role Role @relation(fields: [roleId], references: [id], onDelete: Cascade)
+}
+
+model Run {
+  id         String    @id @default(cuid())
+  startedAt DateTime  @default(now())
+  finishedAt DateTime?
+  rolesFound Int      @default(0)
+  newRoles   Int      @default(0)
+  errors     String   @default("[]")
+}

--- a/src/app/api/assess/route.ts
+++ b/src/app/api/assess/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { assessRole } from "@/lib/dailyRun";
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const result = await assessRole(String(body.roleId), String(body.profileId));
+  return NextResponse.json(result);
+}

--- a/src/app/api/assessments/[id]/materials/route.ts
+++ b/src/app/api/assessments/[id]/materials/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { callModel } from "@/lib/llm";
+import { cvPrompt, coverPrompt } from "@/lib/prompts";
+import { parseModelJson } from "@/lib/json";
+import { assertNoContractions } from "@/lib/validators";
+
+export async function POST(_request: Request, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const assessment = await prisma.assessment.findUniqueOrThrow({
+    where: { id },
+    include: { role: true, profile: true }
+  });
+
+  const keywords = JSON.parse(assessment.keywords) as string[];
+  const bulletsRaw = await callModel(cvPrompt(assessment.profile.fullText, assessment.role.title, assessment.role.company, assessment.role.description, keywords), 60000);
+  const bullets = parseModelJson<string[]>(bulletsRaw);
+  const coverEmail = await callModel(coverPrompt(assessment.profile.fullText, assessment.profile.name, assessment.role.title, assessment.role.company, assessment.role.description), 60000);
+
+  assertNoContractions([...bullets, coverEmail].join("\n"));
+
+  const updated = await prisma.assessment.update({
+    where: { id },
+    data: { cvBullets: JSON.stringify(bullets), coverEmail }
+  });
+
+  return NextResponse.json(updated);
+}

--- a/src/app/api/assessments/route.ts
+++ b/src/app/api/assessments/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { assessRole } from "@/lib/dailyRun";
+import { callModel } from "@/lib/llm";
+import { parseModelJson } from "@/lib/json";
+import { assertNoContractions } from "@/lib/validators";
+import { coverPrompt, cvPrompt } from "@/lib/prompts";
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const assessment = await assessRole(String(body.roleId), String(body.profileId));
+  return NextResponse.json(assessment, { status: 201 });
+}
+
+export async function PATCH(request: Request) {
+  const body = await request.json();
+  const assessment = await prisma.assessment.findUniqueOrThrow({
+    where: { id: String(body.assessmentId) },
+    include: { role: true, profile: true }
+  });
+  const keywords = JSON.parse(assessment.keywords) as string[];
+
+  const cvText = await callModel(cvPrompt(assessment.profile.fullText, assessment.role.title, assessment.role.company, assessment.role.description, keywords), 60000);
+  const cvBullets = parseModelJson<string[]>(cvText);
+  cvBullets.forEach(assertNoContractions);
+
+  const coverEmail = await callModel(coverPrompt(assessment.profile.fullText, assessment.profile.name, assessment.role.title, assessment.role.company, assessment.role.description), 60000);
+  assertNoContractions(coverEmail);
+
+  const updated = await prisma.assessment.update({
+    where: { id: assessment.id },
+    data: {
+      cvBullets: JSON.stringify(cvBullets),
+      coverEmail
+    }
+  });
+  return NextResponse.json(updated);
+}

--- a/src/app/api/cv-bullets/route.ts
+++ b/src/app/api/cv-bullets/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { cvPrompt } from "@/lib/prompts";
+import { callModel } from "@/lib/llm";
+import { parseModelJson } from "@/lib/json";
+import { assertNoContractions } from "@/lib/validators";
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const row = await prisma.assessment.findUniqueOrThrow({
+    where: { id: String(body.id) },
+    include: { role: true, profile: true }
+  });
+  const words = JSON.parse(row.keywords) as string[];
+  const text = await callModel(cvPrompt(row.profile.fullText, row.role.title, row.role.company, row.role.description, words), 60000);
+  const bullets = parseModelJson<string[]>(text);
+  for (const bullet of bullets) assertNoContractions(bullet);
+  const saved = await prisma.assessment.update({ where: { id: row.id }, data: { cvBullets: JSON.stringify(bullets) } });
+  return NextResponse.json(saved);
+}

--- a/src/app/api/data/route.ts
+++ b/src/app/api/data/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+  const data = {
+    profiles: await prisma.candidateProfile.findMany(),
+    searchConfigs: await prisma.searchConfig.findMany(),
+    roles: await prisma.role.findMany(),
+    assessments: await prisma.assessment.findMany(),
+    applications: await prisma.application.findMany(),
+    runs: await prisma.run.findMany()
+  };
+  return NextResponse.json(data);
+}
+
+export async function DELETE() {
+  await prisma.$transaction([
+    prisma.application.deleteMany(),
+    prisma.assessment.deleteMany(),
+    prisma.role.deleteMany(),
+    prisma.searchConfig.deleteMany(),
+    prisma.candidateProfile.deleteMany(),
+    prisma.run.deleteMany()
+  ]);
+  return NextResponse.json({ deleted: true });
+}

--- a/src/app/api/draft-message/route.ts
+++ b/src/app/api/draft-message/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { coverPrompt } from "@/lib/prompts";
+import { callModel } from "@/lib/llm";
+import { assertNoContractions } from "@/lib/validators";
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const row = await prisma.assessment.findUniqueOrThrow({
+    where: { id: String(body.id) },
+    include: { role: true, profile: true }
+  });
+  const text = await callModel(coverPrompt(row.profile.fullText, row.profile.name, row.role.title, row.role.company, row.role.description), 60000);
+  assertNoContractions(text);
+  const saved = await prisma.assessment.update({ where: { id: row.id }, data: { coverEmail: text } });
+  return NextResponse.json(saved);
+}

--- a/src/app/api/export-delete/route.ts
+++ b/src/app/api/export-delete/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function POST() {
+  const data = {
+    profiles: await prisma.candidateProfile.findMany(),
+    searchConfigs: await prisma.searchConfig.findMany(),
+    roles: await prisma.role.findMany(),
+    assessments: await prisma.assessment.findMany(),
+    applications: await prisma.application.findMany(),
+    runs: await prisma.run.findMany()
+  };
+
+  await prisma.application.deleteMany();
+  await prisma.assessment.deleteMany();
+  await prisma.role.deleteMany();
+  await prisma.searchConfig.deleteMany();
+  await prisma.candidateProfile.deleteMany();
+  await prisma.run.deleteMany();
+
+  return new NextResponse(JSON.stringify(data, null, 2), {
+    headers: {
+      "content-type": "application/json",
+      "content-disposition": "attachment; filename=deal-desk-export.json"
+    }
+  });
+}

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { env } from "@/lib/env";
+import { fetchWithTimeout } from "@/lib/http";
+
+async function check(name: string, fn: () => Promise<unknown>) {
+  try {
+    await fn();
+    return { name, status: "PASS" };
+  } catch (error) {
+    return { name, status: "FAIL", message: (error as Error).message };
+  }
+}
+
+export async function GET() {
+  const checks = await Promise.all([
+    check("database", () => prisma.$queryRaw`SELECT 1`),
+    check("model_provider", async () => {
+      if (!env("LLM_PROVIDER") || !env("LLM_MODEL")) throw new Error("LLM provider or model not configured.");
+    }),
+    check("adzuna", async () => {
+      if (!env("ADZUNA_APP_ID") || !env("ADZUNA_APP_KEY")) throw new Error("Adzuna credentials not configured.");
+      await fetchWithTimeout(`https://api.adzuna.com/v1/api/jobs/fr/search/1?app_id=${env("ADZUNA_APP_ID")}&app_key=${env("ADZUNA_APP_KEY")}&what=procurement&results_per_page=1`, {}, 10000);
+    }),
+    check("france_travail", async () => {
+      if (!env("FRANCE_TRAVAIL_CLIENT_ID") || !env("FRANCE_TRAVAIL_CLIENT_SECRET")) throw new Error("France Travail credentials not configured.");
+    })
+  ]);
+
+  return NextResponse.json({ checks });
+}

--- a/src/app/api/list-roles/route.ts
+++ b/src/app/api/list-roles/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+  const rows = await prisma.role.findMany({
+    orderBy: { discoveredAt: "desc" },
+    take: 100
+  });
+  return NextResponse.json(rows);
+}

--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+
+const profileSchema = z.object({
+  id: z.string().optional(),
+  label: z.string().min(1),
+  name: z.string().min(1),
+  email: z.string().email().optional().or(z.literal("")),
+  phone: z.string().optional(),
+  fullText: z.string().min(20),
+  targetTitles: z.array(z.string()).default([]),
+  locations: z.array(z.string()).default([]),
+  isDefault: z.boolean().default(false)
+});
+
+export async function GET() {
+  const profiles = await prisma.candidateProfile.findMany({ orderBy: [{ isDefault: "desc" }, { createdAt: "asc" }] });
+  return NextResponse.json(profiles);
+}
+
+export async function POST(request: Request) {
+  const parsed = profileSchema.parse(await request.json());
+  const data = {
+    ...parsed,
+    email: parsed.email || null,
+    targetTitles: JSON.stringify(parsed.targetTitles),
+    locations: JSON.stringify(parsed.locations)
+  };
+
+  const profile = parsed.id
+    ? await prisma.candidateProfile.update({ where: { id: parsed.id }, data })
+    : await prisma.candidateProfile.create({ data });
+
+  return NextResponse.json(profile);
+}

--- a/src/app/api/roles/[id]/assess/route.ts
+++ b/src/app/api/roles/[id]/assess/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { assessRole } from "@/lib/dailyRun";
+
+const schema = z.object({ profileId: z.string() });
+
+export async function POST(request: Request, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const { profileId } = schema.parse(await request.json());
+  const assessment = await assessRole(id, profileId);
+  return NextResponse.json(assessment);
+}

--- a/src/app/api/roles/route.ts
+++ b/src/app/api/roles/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+  const roles = await prisma.role.findMany({
+    include: { assessments: true, application: true },
+    orderBy: { discoveredAt: "desc" },
+    take: 100
+  });
+  return NextResponse.json(roles);
+}

--- a/src/app/api/run/daily/route.ts
+++ b/src/app/api/run/daily/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { env } from "@/lib/env";
+import { runDaily } from "@/lib/dailyRun";
+
+export async function POST(request: Request) {
+  const expected = env("RUN_SECRET");
+  const provided = request.headers.get("x-run-secret");
+
+  if (!expected || provided !== expected) {
+    return NextResponse.json({ error: "Unauthorised daily run request." }, { status: 401 });
+  }
+
+  const run = await runDaily();
+  return NextResponse.json(run);
+}

--- a/src/app/api/search-configs/route.ts
+++ b/src/app/api/search-configs/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+
+const schema = z.object({
+  id: z.string().optional(),
+  profileId: z.string(),
+  label: z.string(),
+  keywords: z.string(),
+  location: z.string(),
+  inseeCode: z.string().optional().nullable(),
+  radiusKm: z.number().int().positive().default(50),
+  romeCodes: z.array(z.string()).default([]),
+  maxDaysOld: z.number().int().positive().default(7),
+  active: z.boolean().default(true)
+});
+
+export async function GET() {
+  const configs = await prisma.searchConfig.findMany({ include: { profile: true } });
+  return NextResponse.json(configs);
+}
+
+export async function POST(request: Request) {
+  const parsed = schema.parse(await request.json());
+  const data = { ...parsed, romeCodes: JSON.stringify(parsed.romeCodes) };
+  const config = parsed.id
+    ? await prisma.searchConfig.update({ where: { id: parsed.id }, data })
+    : await prisma.searchConfig.create({ data });
+  return NextResponse.json(config);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,72 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f3ee;
+  --panel: #ffffff;
+  --ink: #1f2933;
+  --muted: #607080;
+  --line: #ded7cc;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+main {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 32px 20px;
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  padding: 20px;
+  box-shadow: 0 10px 30px rgba(31, 41, 51, 0.06);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+textarea, input, select {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 10px;
+  font: inherit;
+  box-sizing: border-box;
+}
+
+button, .button {
+  border: 0;
+  border-radius: 999px;
+  background: #1f2933;
+  color: white;
+  padding: 10px 16px;
+  font-weight: 700;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  padding: 10px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: top;
+}
+
+small, .muted {
+  color: var(--muted);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "The Deal Desk",
+  description: "AI-assisted job-search desk for procurement professionals"
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en-GB">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,6 @@ async function seedDefaults() {
     data: {
       label: "Ayo",
       name: "Ayodele Okoh",
-      email: "ayookoh@gmail.com",
       fullText: ayoProfile,
       targetTitles: JSON.stringify(["IT Category Manager", "IT Procurement Manager", "Strategic Sourcing Manager IT", "Vendor Risk Lead"]),
       locations: JSON.stringify(["France", "Remote Europe", "Île-de-France"]),
@@ -22,9 +21,9 @@ async function seedDefaults() {
     }
   });
 
-  await prisma.candidateProfile.create({
+  const second = await prisma.candidateProfile.create({
     data: {
-      label: "Second profile",
+      label: "Second candidate",
       name: "Profile owner",
       fullText: "Paste the second candidate's complete CV and target roles here. This profile is deliberately editable and does not contain invented achievements.",
       targetTitles: JSON.stringify([]),
@@ -32,17 +31,29 @@ async function seedDefaults() {
     }
   });
 
-  await prisma.searchConfig.create({
-    data: {
-      profileId: ayo.id,
-      label: "Ayo — IT procurement France and remote Europe",
-      keywords: "IT Procurement Manager OR IT Category Manager OR Strategic Sourcing Manager IT",
-      location: "Île-de-France",
-      inseeCode: "78120",
-      radiusKm: 80,
-      maxDaysOld: 7,
-      romeCodes: JSON.stringify(["M1101", "M1102"])
-    }
+  await prisma.searchConfig.createMany({
+    data: [
+      {
+        profileId: ayo.id,
+        label: "Ayo — IT procurement France and remote Europe",
+        keywords: "IT Procurement Manager OR IT Category Manager OR Strategic Sourcing Manager IT",
+        location: "Île-de-France",
+        inseeCode: "78120",
+        radiusKm: 80,
+        maxDaysOld: 7,
+        romeCodes: JSON.stringify(["M1101", "M1102"])
+      },
+      {
+        profileId: second.id,
+        label: "Second candidate — configure target search",
+        keywords: "",
+        location: "France",
+        radiusKm: 80,
+        maxDaysOld: 7,
+        romeCodes: JSON.stringify([]),
+        active: false
+      }
+    ]
   });
 }
 
@@ -58,7 +69,7 @@ export default async function Home() {
   return (
     <main>
       <h1>The Deal Desk</h1>
-      <p className="muted">Multi-profile AI job-search desk for senior procurement applications. Your profile and your wife's profile can run separately with their own targets, locations and pipeline history.</p>
+      <p className="muted">Multi-profile AI job-search desk for senior procurement applications. Each candidate profile runs with its own targets, locations and pipeline history.</p>
 
       <div className="grid">
         <section className="card">
@@ -66,7 +77,7 @@ export default async function Home() {
           {profiles.map((profile) => (
             <p key={profile.id}><strong>{profile.label}</strong><br /><small>{profile.name}</small></p>
           ))}
-          <p className="muted">Edit screens are scaffolded through the API. The next UI step is a richer profile editor with autosave.</p>
+          <p className="muted">Use the profile API to update each CV, contact fields, target titles and preferred locations.</p>
         </section>
 
         <section className="card">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,104 @@
+import { prisma } from "@/lib/prisma";
+
+const ayoProfile = `Ayodele Okoh is an IT Category Manager and IT procurement professional based in Rambouillet, France, open to remote roles within Europe. He has fifteen years of IT procurement experience across hardware, software, SaaS, cloud, telecom, vendor risk, contract optimisation and regulated environments.
+
+Experience includes Senior IT Buyer work at BNP Paribas CIB covering banking IT procurement, FIS, Microsoft, SAP ECC 6.0 migration exposure, Atlassian and strategic supplier governance. At Najar / Welii he focuses on SaaS and AI contract optimisation, enterprise software negotiation and supplier risk management. Earlier experience includes building procurement functions from zero at Dangote and SPS Nexus, including team leadership, direct budget ownership and pan-African IT contract frameworks.
+
+Education includes an MBA from ISC Paris, CSCP from APICS and an engineering background. Languages: English native, French professional. Target roles include IT Category Manager, IT Procurement Manager, Strategic Sourcing Manager for IT, Vendor Risk Lead and Vendor Management Lead.`;
+
+async function seedDefaults() {
+  const count = await prisma.candidateProfile.count();
+  if (count > 0) return;
+
+  const ayo = await prisma.candidateProfile.create({
+    data: {
+      label: "Ayo",
+      name: "Ayodele Okoh",
+      email: "ayookoh@gmail.com",
+      fullText: ayoProfile,
+      targetTitles: JSON.stringify(["IT Category Manager", "IT Procurement Manager", "Strategic Sourcing Manager IT", "Vendor Risk Lead"]),
+      locations: JSON.stringify(["France", "Remote Europe", "Île-de-France"]),
+      isDefault: true
+    }
+  });
+
+  await prisma.candidateProfile.create({
+    data: {
+      label: "Second profile",
+      name: "Profile owner",
+      fullText: "Paste the second candidate's complete CV and target roles here. This profile is deliberately editable and does not contain invented achievements.",
+      targetTitles: JSON.stringify([]),
+      locations: JSON.stringify(["France", "Remote Europe"])
+    }
+  });
+
+  await prisma.searchConfig.create({
+    data: {
+      profileId: ayo.id,
+      label: "Ayo — IT procurement France and remote Europe",
+      keywords: "IT Procurement Manager OR IT Category Manager OR Strategic Sourcing Manager IT",
+      location: "Île-de-France",
+      inseeCode: "78120",
+      radiusKm: 80,
+      maxDaysOld: 7,
+      romeCodes: JSON.stringify(["M1101", "M1102"])
+    }
+  });
+}
+
+export default async function Home() {
+  await seedDefaults();
+
+  const [profiles, roles, assessments] = await Promise.all([
+    prisma.candidateProfile.findMany({ orderBy: [{ isDefault: "desc" }, { createdAt: "asc" }] }),
+    prisma.role.findMany({ orderBy: { discoveredAt: "desc" }, take: 8 }),
+    prisma.assessment.findMany({ include: { role: true, profile: true }, orderBy: { createdAt: "desc" }, take: 8 })
+  ]);
+
+  return (
+    <main>
+      <h1>The Deal Desk</h1>
+      <p className="muted">Multi-profile AI job-search desk for senior procurement applications. Your profile and your wife's profile can run separately with their own targets, locations and pipeline history.</p>
+
+      <div className="grid">
+        <section className="card">
+          <h2>Candidate profiles</h2>
+          {profiles.map((profile) => (
+            <p key={profile.id}><strong>{profile.label}</strong><br /><small>{profile.name}</small></p>
+          ))}
+          <p className="muted">Edit screens are scaffolded through the API. The next UI step is a richer profile editor with autosave.</p>
+        </section>
+
+        <section className="card">
+          <h2>Find roles now</h2>
+          <p>Trigger the protected daily run from your scheduler or locally with the shared secret.</p>
+          <code>POST /api/run/daily</code>
+        </section>
+
+        <section className="card">
+          <h2>Recent roles</h2>
+          {roles.length === 0 ? <p className="muted">No roles sourced yet.</p> : roles.map((role) => (
+            <p key={role.id}><strong>{role.title}</strong><br /><small>{role.company} — {role.location}</small></p>
+          ))}
+        </section>
+      </div>
+
+      <section className="card" style={{ marginTop: 16 }}>
+        <h2>Assessment history</h2>
+        <table>
+          <thead><tr><th>Candidate</th><th>Role</th><th>Score</th><th>Verdict</th></tr></thead>
+          <tbody>
+            {assessments.map((a) => (
+              <tr key={a.id}>
+                <td>{a.profile.label}</td>
+                <td>{a.role.title}<br /><small>{a.role.company}</small></td>
+                <td>{a.tier} {a.fitScore}/100</td>
+                <td>{a.verdict}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </main>
+  );
+}

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -1,0 +1,45 @@
+import { prisma } from "./prisma";
+import { ayoDefaultProfile, wifePlaceholderProfile } from "./profileSeed";
+
+export async function ensureDefaultData() {
+  const count = await prisma.candidateProfile.count();
+  if (count > 0) return;
+
+  const primary = await prisma.candidateProfile.create({
+    data: {
+      label: ayoDefaultProfile.label,
+      name: ayoDefaultProfile.name,
+      fullText: ayoDefaultProfile.fullText,
+      email: process.env.DIGEST_TO_EMAIL || null,
+      phone: null,
+      targetTitles: JSON.stringify(ayoDefaultProfile.targetTitles),
+      locations: JSON.stringify(ayoDefaultProfile.locations),
+      isDefault: true
+    }
+  });
+
+  await prisma.candidateProfile.create({
+    data: {
+      label: wifePlaceholderProfile.label,
+      name: wifePlaceholderProfile.name,
+      fullText: wifePlaceholderProfile.fullText,
+      targetTitles: JSON.stringify(wifePlaceholderProfile.targetTitles),
+      locations: JSON.stringify(wifePlaceholderProfile.locations),
+      isDefault: false
+    }
+  });
+
+  await prisma.searchConfig.create({
+    data: {
+      profileId: primary.id,
+      label: "IT procurement France",
+      keywords: "IT Procurement Manager IT Category Manager Strategic Sourcing IT",
+      location: "Paris",
+      inseeCode: "75056",
+      radiusKm: 80,
+      romeCodes: JSON.stringify(["M1101", "M1102"]),
+      maxDaysOld: 7,
+      active: true
+    }
+  });
+}

--- a/src/lib/dailyRun.ts
+++ b/src/lib/dailyRun.ts
@@ -1,0 +1,112 @@
+import { prisma } from "./prisma";
+import { fetchAdzuna, fetchFranceTravail } from "./jobSources";
+import { firstPassScore } from "./scoring";
+import { assessmentPrompt } from "./prompts";
+import { callModel } from "./llm";
+import { parseModelJson } from "./json";
+import { sendDigest } from "./email";
+import { appConfig } from "./env";
+
+type AssessmentJson = {
+  fit_score: number;
+  tier: "A" | "B" | "C";
+  verdict: string;
+  strengths: string[];
+  gaps: string[];
+  keywords: string[];
+};
+
+export async function assessRole(roleId: string, profileId: string) {
+  const [role, profile] = await Promise.all([
+    prisma.role.findUniqueOrThrow({ where: { id: roleId } }),
+    prisma.candidateProfile.findUniqueOrThrow({ where: { id: profileId } })
+  ]);
+
+  const raw = await callModel(assessmentPrompt(profile.fullText, role.title, role.company, role.description), 30000);
+  const parsed = parseModelJson<AssessmentJson>(raw);
+
+  return prisma.assessment.create({
+    data: {
+      roleId,
+      profileId,
+      fitScore: parsed.fit_score,
+      tier: parsed.tier,
+      verdict: parsed.verdict,
+      strengths: JSON.stringify(parsed.strengths),
+      gaps: JSON.stringify(parsed.gaps),
+      keywords: JSON.stringify(parsed.keywords)
+    }
+  });
+}
+
+export async function runDaily() {
+  const run = await prisma.run.create({ data: {} });
+  const errors: string[] = [];
+  let rolesFound = 0;
+  let newRoles = 0;
+
+  const configs = await prisma.searchConfig.findMany({
+    where: { active: true },
+    include: { profile: true }
+  });
+
+  for (const config of configs) {
+    try {
+      const input = {
+        keywords: config.keywords,
+        location: config.location,
+        inseeCode: config.inseeCode,
+        radiusKm: config.radiusKm,
+        maxDaysOld: config.maxDaysOld
+      };
+      const sourced = [...await fetchAdzuna(input), ...await fetchFranceTravail(input)];
+      rolesFound += sourced.length;
+
+      for (const role of sourced) {
+        const created = await prisma.role.upsert({
+          where: { dedupeHash: role.dedupeHash },
+          update: {},
+          create: {
+            ...role,
+            firstPassScore: firstPassScore(config.profile.fullText, role.description)
+          }
+        });
+        if (created.discoveredAt > run.startedAt) newRoles += 1;
+      }
+
+      const topRoles = await prisma.role.findMany({
+        where: { assessments: { none: { profileId: config.profileId } } },
+        orderBy: { firstPassScore: "desc" },
+        take: 5
+      });
+
+      for (const role of topRoles) {
+        try {
+          await assessRole(role.id, config.profileId);
+        } catch (error) {
+          errors.push(`Assessment failed for ${role.title}: ${(error as Error).message}`);
+        }
+      }
+    } catch (error) {
+      errors.push(`Search ${config.label} failed: ${(error as Error).message}`);
+    }
+  }
+
+  const topAssessments = await prisma.assessment.findMany({
+    include: { role: true, profile: true },
+    orderBy: { createdAt: "desc" },
+    take: 10
+  });
+
+  const bestScore = topAssessments[0]?.fitScore ?? 0;
+  const html = `<h1>Deal Desk daily roles</h1>${topAssessments.map((a) =>
+    `<p><strong>${a.profile.label}: ${a.tier} ${a.fitScore}/100</strong> — ${a.role.title} at ${a.role.company}<br/>${a.verdict}<br/><a href="${appConfig.appBaseUrl}/roles/${a.roleId}">Open role</a></p>`
+  ).join("")}`;
+
+  await sendDigest(`Deal Desk — ${newRoles} new roles, top fit ${bestScore}/100`, html);
+
+  return prisma.run.update({
+    where: { id: run.id },
+    data: { finishedAt: new Date(), rolesFound, newRoles, errors: JSON.stringify(errors) }
+  });
+}

--- a/src/lib/dedupe.test.ts
+++ b/src/lib/dedupe.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { roleDedupeHash } from "./dedupe";
+
+describe("role dedupe", () => {
+  it("normalises case and spacing", () => {
+    expect(roleDedupeHash("ACME", "IT Buyer", "Paris")).toBe(roleDedupeHash(" acme ", "it buyer", "paris"));
+  });
+});

--- a/src/lib/dedupe.ts
+++ b/src/lib/dedupe.ts
@@ -1,0 +1,8 @@
+import crypto from "node:crypto";
+
+export function roleDedupeHash(company: string, title: string, location: string): string {
+  return crypto
+    .createHash("sha256")
+    .update(`${company}|${title}|${location}`.toLowerCase().replace(/\s+/g, " ").trim())
+    .digest("hex");
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,33 @@
+import nodemailer from "nodemailer";
+import { Resend } from "resend";
+import { env } from "./env";
+
+export async function sendDigest(subject: string, html: string): Promise<void> {
+  const to = env("DIGEST_TO_EMAIL");
+  if (!to) return;
+
+  if (env("RESEND_API_KEY")) {
+    const resend = new Resend(env("RESEND_API_KEY"));
+    await resend.emails.send({
+      from: env("SMTP_FROM", "Deal Desk <noreply@example.com>"),
+      to,
+      subject,
+      html
+    });
+    return;
+  }
+
+  if (env("SMTP_HOST")) {
+    const transporter = nodemailer.createTransport({
+      host: env("SMTP_HOST"),
+      port: Number(env("SMTP_PORT", "587")),
+      auth: env("SMTP_USER") ? { user: env("SMTP_USER"), pass: env("SMTP_PASS") } : undefined
+    });
+    await transporter.sendMail({
+      from: env("SMTP_FROM", "Deal Desk <noreply@example.com>"),
+      to,
+      subject,
+      html
+    });
+  }
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,14 @@
+export function env(name: string, fallback = ""): string {
+  return process.env[name] ?? fallback;
+}
+
+export function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+export const appConfig = {
+  timezone: env("TIMEZONE", "Europe/Paris"),
+  appBaseUrl: env("APP_BASE_URL", "http://localhost:3000")
+};

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,0 +1,39 @@
+export class ExternalCallError extends Error {
+  constructor(
+    message: string,
+    public status?: number,
+    public providerMessage?: string
+  ) {
+    super(message);
+  }
+}
+
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit = {},
+  timeoutMs = 30000
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, { ...init, signal: controller.signal });
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new ExternalCallError(
+        `External call failed with HTTP ${response.status}`,
+        response.status,
+        body.slice(0, 500)
+      );
+    }
+    return response;
+  } catch (error) {
+    if (error instanceof ExternalCallError) throw error;
+    if ((error as Error).name === "AbortError") {
+      throw new ExternalCallError(`External call timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/lib/jobSources.ts
+++ b/src/lib/jobSources.ts
@@ -1,0 +1,108 @@
+import { env } from "./env";
+import { fetchWithTimeout } from "./http";
+import { roleDedupeHash } from "./dedupe";
+
+export type NormalisedRole = {
+  source: string;
+  sourceId: string;
+  dedupeHash: string;
+  title: string;
+  company: string;
+  location: string;
+  description: string;
+  url: string;
+  salary?: string;
+  postedAt?: Date;
+};
+
+type SearchInput = {
+  keywords: string;
+  location: string;
+  inseeCode?: string | null;
+  radiusKm: number;
+  maxDaysOld: number;
+};
+
+export async function fetchAdzuna(input: SearchInput): Promise<NormalisedRole[]> {
+  if (!env("ADZUNA_APP_ID") || !env("ADZUNA_APP_KEY")) return [];
+  const params = new URLSearchParams({
+    app_id: env("ADZUNA_APP_ID"),
+    app_key: env("ADZUNA_APP_KEY"),
+    what: input.keywords,
+    where: input.location,
+    max_days_old: String(input.maxDaysOld),
+    results_per_page: "25",
+    sort_by: "date"
+  });
+  const response = await fetchWithTimeout(`https://api.adzuna.com/v1/api/jobs/fr/search/1?${params}`, {}, 30000);
+  const json = await response.json();
+
+  return (json.results ?? []).map((item: any) => {
+    const company = item.company?.display_name ?? "Unknown company";
+    const title = item.title ?? "Untitled role";
+    const location = item.location?.display_name ?? input.location;
+    return {
+      source: "adzuna",
+      sourceId: String(item.id),
+      dedupeHash: roleDedupeHash(company, title, location),
+      title,
+      company,
+      location,
+      description: item.description ?? "",
+      url: item.redirect_url ?? "",
+      salary: item.salary_min || item.salary_max ? `${item.salary_min ?? ""} - ${item.salary_max ?? ""}` : undefined,
+      postedAt: item.created ? new Date(item.created) : undefined
+    };
+  });
+}
+
+async function franceTravailToken(): Promise<string | null> {
+  if (!env("FRANCE_TRAVAIL_CLIENT_ID") || !env("FRANCE_TRAVAIL_CLIENT_SECRET")) return null;
+  const body = new URLSearchParams({
+    grant_type: "client_credentials",
+    client_id: env("FRANCE_TRAVAIL_CLIENT_ID"),
+    client_secret: env("FRANCE_TRAVAIL_CLIENT_SECRET"),
+    scope: "api_offresdemploiv2 o2dsoffre"
+  });
+  const response = await fetchWithTimeout("https://entreprise.francetravail.fr/connexion/oauth2/access_token?realm=%2Fpartenaire", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body
+  }, 30000);
+  const json = await response.json();
+  return json.access_token ?? null;
+}
+
+export async function fetchFranceTravail(input: SearchInput): Promise<NormalisedRole[]> {
+  const token = await franceTravailToken();
+  if (!token) return [];
+
+  const params = new URLSearchParams({
+    motsCles: input.keywords,
+    rayon: String(input.radiusKm)
+  });
+  if (input.inseeCode) params.set("commune", input.inseeCode);
+
+  const response = await fetchWithTimeout(`https://api.francetravail.io/partenaire/offresdemploi/v2/offres/search?${params}`, {
+    headers: { authorization: `Bearer ${token}` }
+  }, 30000);
+  const json = await response.json();
+
+  return (json.resultats ?? []).map((item: any) => {
+    const company = item.entreprise?.nom ?? "Unknown company";
+    const title = item.intitule ?? "Untitled role";
+    const location = item.lieuTravail?.libelle ?? input.location;
+    return {
+      source: "france_travail",
+      sourceId: String(item.id),
+      dedupeHash: roleDedupeHash(company, title, location),
+      title,
+      company,
+      location,
+      description: item.description ?? "",
+      url: item.origineOffre?.urlOrigine ?? "",
+      salary: item.salaire?.libelle,
+      postedAt: item.dateCreation ? new Date(item.dateCreation) : undefined
+    };
+  });
+}

--- a/src/lib/json.test.ts
+++ b/src/lib/json.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { parseModelJson } from "./json";
+
+describe("model JSON parser", () => {
+  it("parses fenced JSON", () => {
+    expect(parseModelJson<{ ok: boolean }>("```json\n{\"ok\":true}\n```").ok).toBe(true);
+  });
+});

--- a/src/lib/json.ts
+++ b/src/lib/json.ts
@@ -1,0 +1,13 @@
+export function parseModelJson<T>(raw: string): T {
+  const cleaned = raw.replace(/```json|```/g, "").trim();
+  const objectStart = cleaned.indexOf("{");
+  const arrayStart = cleaned.indexOf("[");
+  const starts = [objectStart, arrayStart].filter((n) => n >= 0);
+  if (!starts.length) throw new Error("No JSON object or array found in model response.");
+
+  const start = Math.min(...starts);
+  const end = Math.max(cleaned.lastIndexOf("}"), cleaned.lastIndexOf("]"));
+  if (end <= start) throw new Error("Malformed JSON returned by model.");
+
+  return JSON.parse(cleaned.slice(start, end + 1)) as T;
+}

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -1,5 +1,16 @@
 import { env } from "./env";
 import { fetchWithTimeout } from "./http";
+import { parseModelJson } from "./json";
+import { assertNoContractions } from "./validators";
+
+export type FitAssessment = {
+  fit_score: number;
+  tier: "A" | "B" | "C";
+  verdict: string;
+  strengths: string[];
+  gaps: string[];
+  keywords: string[];
+};
 
 export async function callModel(prompt: string, timeoutMs = 30000): Promise<string> {
   const provider = env("LLM_PROVIDER");
@@ -8,15 +19,8 @@ export async function callModel(prompt: string, timeoutMs = 30000): Promise<stri
   if (provider === "openai") {
     const response = await fetchWithTimeout("https://api.openai.com/v1/chat/completions", {
       method: "POST",
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${env("OPENAI_API_KEY")}`
-      },
-      body: JSON.stringify({
-        model,
-        messages: [{ role: "user", content: prompt }],
-        temperature: 0.2
-      })
+      headers: { "content-type": "application/json", authorization: `Bearer ${env("OPENAI_API_KEY")}` },
+      body: JSON.stringify({ model, messages: [{ role: "user", content: prompt }], temperature: 0.2 })
     }, timeoutMs);
     const json = await response.json();
     return json.choices?.[0]?.message?.content ?? "";
@@ -25,20 +29,31 @@ export async function callModel(prompt: string, timeoutMs = 30000): Promise<stri
   if (provider === "anthropic") {
     const response = await fetchWithTimeout("https://api.anthropic.com/v1/messages", {
       method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-api-key": env("ANTHROPIC_API_KEY"),
-        "anthropic-version": "2023-06-01"
-      },
-      body: JSON.stringify({
-        model,
-        max_tokens: 1600,
-        messages: [{ role: "user", content: prompt }]
-      })
+      headers: { "content-type": "application/json", "x-api-key": env("ANTHROPIC_API_KEY"), "anthropic-version": "2023-06-01" },
+      body: JSON.stringify({ model, max_tokens: 1800, temperature: 0.2, messages: [{ role: "user", content: prompt }] })
     }, timeoutMs);
     const json = await response.json();
     return json.content?.map((part: { text?: string }) => part.text ?? "").join("") ?? "";
   }
 
   throw new Error("LLM_PROVIDER must be set to openai or anthropic.");
+}
+
+export async function assessFit(profile: string, roleTitle: string, company: string, jobDescription: string): Promise<FitAssessment> {
+  const prompt = `You are a senior recruitment assessor for IT procurement roles. Compare the candidate profile against the job description. Return only JSON with this shape: {"fit_score": 0, "tier": "A", "verdict": "one sentence", "strengths": [], "gaps": [], "keywords": []}. Tier A is 80 or above, B is 60 to 79, and C is below 60. Be strict and do not inflate the score.\n\nCANDIDATE PROFILE:\n${profile}\n\nJOB DESCRIPTION (${roleTitle} at ${company}):\n${jobDescription}`;
+  return parseModelJson<FitAssessment>(await callModel(prompt, 30000));
+}
+
+export async function tailorCv(profile: string, roleTitle: string, company: string, jobDescription: string, keywords: string[]): Promise<string[]> {
+  const prompt = `Write in formal British English. Never use contractions. Rewrite the candidate experience as seven CV bullet points tailored to this job description. Use these ATS keywords where truthful: ${keywords.join(", ")}. Each bullet must start with a strong verb and include scale or impact where the profile supports it. Never invent facts. Return only a JSON array of strings.\n\nCANDIDATE PROFILE:\n${profile}\n\nJOB DESCRIPTION (${roleTitle} at ${company}):\n${jobDescription}`;
+  const bullets = parseModelJson<string[]>(await callModel(prompt, 60000));
+  bullets.forEach(assertNoContractions);
+  return bullets;
+}
+
+export async function draftCoverEmail(profile: string, candidateName: string, roleTitle: string, company: string, jobDescription: string): Promise<string> {
+  const prompt = `Write in formal British English. Never use contractions. Draft a concise cover email of 170 to 220 words for ${roleTitle} at ${company}, from ${candidateName}. Put the subject line on the first line as Subject:. Use two short paragraphs with concrete achievements from the profile and close by requesting a conversation.\n\nCANDIDATE PROFILE:\n${profile}\n\nJOB DESCRIPTION:\n${jobDescription}`;
+  const email = await callModel(prompt, 60000);
+  assertNoContractions(email);
+  return email;
 }

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -1,0 +1,44 @@
+import { env } from "./env";
+import { fetchWithTimeout } from "./http";
+
+export async function callModel(prompt: string, timeoutMs = 30000): Promise<string> {
+  const provider = env("LLM_PROVIDER");
+  const model = env("LLM_MODEL");
+
+  if (provider === "openai") {
+    const response = await fetchWithTimeout("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${env("OPENAI_API_KEY")}`
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: prompt }],
+        temperature: 0.2
+      })
+    }, timeoutMs);
+    const json = await response.json();
+    return json.choices?.[0]?.message?.content ?? "";
+  }
+
+  if (provider === "anthropic") {
+    const response = await fetchWithTimeout("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": env("ANTHROPIC_API_KEY"),
+        "anthropic-version": "2023-06-01"
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: 1600,
+        messages: [{ role: "user", content: prompt }]
+      })
+    }, timeoutMs);
+    const json = await response.json();
+    return json.content?.map((part: { text?: string }) => part.text ?? "").join("") ?? "";
+  }
+
+  throw new Error("LLM_PROVIDER must be set to openai or anthropic.");
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === "development" ? ["error", "warn"] : ["error"]
+  });
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/src/lib/profileSeed.ts
+++ b/src/lib/profileSeed.ts
@@ -1,0 +1,19 @@
+export const ayoDefaultProfile = {
+  label: "Ayo",
+  name: "Ayodele Okoh",
+  fullText: `Ayodele Okoh is an IT Category Manager and IT Procurement Manager based in Rambouillet, France, open to remote roles across Europe. He has fifteen years of IT procurement experience across hardware, software, SaaS, cloud, telecom, outsourcing, vendor risk and regulated technology environments.
+
+He has held senior roles at BNP Paribas CIB, Najar / Welii, Dangote and SPS Nexus. His experience includes banking IT procurement, FIS, Finastra, Calypso, Microsoft, Adobe, SAP, Atlassian, SaaS and AI contract optimisation, enterprise software negotiation, supplier risk management, DORA-related vendor analysis and pan-Africa IT contract frameworks.
+
+He has built procurement functions from zero, including a team of seven at Dangote and a team of five at SPS Nexus. He holds an MBA from ISC Paris, CSCP from APICS and an engineering background. He writes and works in English, with professional French capability. Target roles include IT Category Manager, IT Procurement Manager, Strategic Sourcing Manager for IT, Vendor Risk Lead and Vendor Management Lead.`,
+  targetTitles: ["IT Category Manager", "IT Procurement Manager", "Strategic Sourcing Manager IT", "Vendor Risk Lead", "Vendor Management Lead"],
+  locations: ["Île-de-France", "Paris", "Remote Europe", "France"]
+};
+
+export const wifePlaceholderProfile = {
+  label: "Second profile",
+  name: "Second candidate",
+  fullText: "Paste the second candidate's full CV, achievements, target roles, languages, preferred locations and constraints here. The application will tailor searches, fit assessments, CV bullets and cover emails to this profile only.",
+  targetTitles: ["Target role"],
+  locations: ["France", "Remote Europe"]
+};

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,0 +1,47 @@
+export function assessmentPrompt(profile: string, roleTitle: string, company: string, jobDescription: string): string {
+  return `You are a senior recruitment assessor for IT procurement roles. Compare the
+candidate profile against the job description and respond with ONLY a JSON
+object, no other text:
+{"fit_score": 0-100, "tier": "A"|"B"|"C",
+ "verdict": "one sentence: apply / apply with adjustments / skip",
+ "strengths": ["3-5 strongest matches"],
+ "gaps": ["2-4 gaps, each with a one-phrase mitigation"],
+ "keywords": ["6-10 ATS keywords from the job description the CV must contain"]}
+Tier A = 80+, B = 60-79, C = below 60. Be brutally honest; do not inflate the score.
+
+CANDIDATE PROFILE:
+${profile}
+
+JOB DESCRIPTION (${roleTitle} at ${company}):
+${jobDescription}`;
+}
+
+export function cvPrompt(profile: string, roleTitle: string, company: string, jobDescription: string, keywords: string[]): string {
+  return `Write in formal British English. Never use contractions: write "do not" instead
+of "don't", "it is" instead of "it's". Rewrite the candidate's experience as 7
+CV bullet points tailored precisely to this job description, weaving in these ATS
+keywords where truthful: ${keywords.join(", ")}. Each bullet must start with a strong verb
+and include scale or impact where the profile supports it. Never invent facts.
+Respond with ONLY a JSON array of strings.
+
+CANDIDATE PROFILE:
+${profile}
+
+JOB DESCRIPTION (${roleTitle} at ${company}):
+${jobDescription}`;
+}
+
+export function coverPrompt(profile: string, candidateName: string, roleTitle: string, company: string, jobDescription: string): string {
+  return `Write in formal British English. Never use contractions. Draft a concise cover
+email of 170 to 220 words for ${roleTitle} at ${company}, from ${candidateName}.
+Structure: a one-line hook tied to the company's context; two short paragraphs
+evidencing fit with concrete achievements from the profile; a confident close
+requesting a conversation. Put the subject line on the first line as
+"Subject: ...". Respond with the email text only.
+
+CANDIDATE PROFILE:
+${profile}
+
+JOB DESCRIPTION:
+${jobDescription}`;
+}

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -1,0 +1,48 @@
+import crypto from "node:crypto";
+
+export type NormalisedRole = {
+  source: string;
+  sourceId: string;
+  title: string;
+  company: string;
+  location: string;
+  description: string;
+  url: string;
+  salary?: string | null;
+  postedAt?: Date | null;
+  firstPassScore: number;
+  dedupeHash: string;
+};
+
+export function makeDedupeHash(company: string, title: string, location: string): string {
+  return crypto
+    .createHash("sha256")
+    .update(`${company}|${title}|${location}`.toLowerCase().replace(/\s+/g, " ").trim())
+    .digest("hex");
+}
+
+export function scoreRole(description: string, profile: string, targetTitles: string[]): number {
+  const haystack = `${description} ${targetTitles.join(" ")}`.toLowerCase();
+  const profileWords = new Set(
+    profile
+      .toLowerCase()
+      .replace(/[^a-z0-9À-ÿ\s-]/gi, " ")
+      .split(/\s+/)
+      .filter((word) => word.length > 4)
+  );
+  const priority = ["procurement", "category", "sourcing", "vendor", "supplier", "software", "saas", "cloud", "it", "risk", "contract", "licence"];
+  let score = 0;
+  for (const word of priority) if (haystack.includes(word)) score += 6;
+  for (const word of profileWords) if (haystack.includes(word)) score += 1;
+  return Math.min(100, score);
+}
+
+export function safeJsonArray(value: string | null | undefined): string[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.map(String) : [];
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -1,0 +1,18 @@
+const importantTerms = [
+  "procurement", "sourcing", "category", "it", "software", "saas", "cloud",
+  "telecom", "vendor", "supplier", "risk", "contract", "negotiation",
+  "dora", "gdpr", "outsourcing", "licence", "licensing", "stakeholder"
+];
+
+export function firstPassScore(profile: string, description: string): number {
+  const haystack = `${profile} ${description}`.toLowerCase();
+  const roleText = description.toLowerCase();
+  let score = 0;
+
+  for (const term of importantTerms) {
+    if (roleText.includes(term)) score += 6;
+    if (haystack.includes(term)) score += 2;
+  }
+
+  return Math.min(100, score);
+}

--- a/src/lib/validators.test.ts
+++ b/src/lib/validators.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { findContractions } from "./validators";
+
+describe("contraction validator", () => {
+  it("flags common contractions", () => {
+    expect(findContractions("I don't think it is ready.")).toContain("don't");
+    expect(findContractions("We are ready.")).toEqual([]);
+  });
+});

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,0 +1,22 @@
+const contractionPatterns = [
+  /\b\w+n't\b/i,
+  /\b(?:I|you|we|they|he|she|it|that|there|here|who|what|where|when|why|how)'(?:m|re|ve|ll|d|s)\b/i,
+  /\b(?:can|won|shan)'t\b/i
+];
+
+export function findContractions(text: string): string[] {
+  const matches = new Set<string>();
+  for (const pattern of contractionPatterns) {
+    for (const match of text.matchAll(new RegExp(pattern.source, "gi"))) {
+      matches.add(match[0]);
+    }
+  }
+  return [...matches];
+}
+
+export function assertNoContractions(text: string): void {
+  const contractions = findContractions(text);
+  if (contractions.length) {
+    throw new Error(`Generated text contains contractions: ${contractions.join(", ")}`);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "ES2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

This branch replaces the previous static driving-practice app with The Deal Desk: a multi-profile job-search application for procurement professionals.

Included:
- Next.js, Prisma and SQLite scaffold.
- Candidate profiles for separate searches and assessments.
- Adzuna and France Travail job-source adapters.
- Protected daily run endpoint for scheduled sourcing and digest delivery.
- OpenAI and Anthropic model adapter behind backend route handlers.
- JSON parsing, generated-text validation and first-pass relevance scoring.
- Export-and-delete endpoint for stored personal data.
- Environment template, Docker setup, DECISIONS.md, AGENTS.md and initial unit tests.

## Note

I could not run dependency installation or the build from this environment because GitHub cloning and package installation are not available here. The next validation step is to pull the branch, run `npm install`, `npx prisma migrate dev --name init`, `npm test` and `npm run build`.